### PR TITLE
Add an attachments section

### DIFF
--- a/jira-api.el
+++ b/jira-api.el
@@ -131,11 +131,12 @@
     (message "[Jira API Response Body]: %s" (or response-data "No response body"))))
 
 
-(cl-defun jira-api-call (verb endpoint &key params data callback)
+(cl-defun jira-api-call (verb endpoint &key params data callback parser)
   "Perform a VERB request to the Jira API ENDPOINT.
 
 PARAMS is a list of cons cells, DATA is the request body, and CALLBACK
-is the function to call if successful."
+is the function to call if successful. PARSER is a function to call
+in a buffer with the result data, defaulting to `json-read'."
   (message "[Jira API Call]: %s %s" verb endpoint)
   (when (and jira-debug data)
     (message "[Jira API Call Data]: %s" (json-encode data)))
@@ -149,7 +150,7 @@ is the function to call if successful."
                  ("Content-Type" . "application/json"))
       :params (or params '())
       :data (if data (json-encode data) nil)
-      :parser 'json-read
+      :parser (or parser 'json-read)
       :success (cl-function
                 (lambda (&key data response &allow-other-keys)
 		  (when jira-debug

--- a/jira-detail.el
+++ b/jira-detail.el
@@ -221,11 +221,13 @@
                                         id)))
                         (magit-insert-section (jira-attachment-section val nil)
                           (magit-insert-section-body
-                            (insert (format "%-40s %s, %sB\n"
+                            (insert (format "%-30s %10s %5sB %s\n"
                                             (alist-get 'filename attachment)
                                             (alist-get 'mimeType attachment)
                                             (file-size-human-readable
-                                             (alist-get 'size attachment))))))))
+                                             (alist-get 'size attachment))
+                                            (jira-fmt-datetime
+                                             (alist-get 'created attachment))))))))
                       attachments)))
           (insert "\n")))))
 

--- a/jira-detail.el
+++ b/jira-detail.el
@@ -236,6 +236,7 @@
   (interactive)
   (pcase (magit-section-value-if [jira-attachment-section])
     (`(,name ,id)
+     (message "Fetching %s..." name)
      (jira-api-call
       "GET" (format "attachment/content/%s" id)
       ;; don't want the default parser `json-read' here: the


### PR DESCRIPTION
Hello,

This PR adds a section listing attachments for the current issue. Pressing `RET` on an attachment downloads it into a buffer. This is based on some code I had using the `jiralib2` package (https://github.com/nyyManni/jiralib2). It only required one change: `jira-api-call` has a new `:parser` keyword arg. This is required because Jira attachment URLS provide raw binary data, instead of JSON like all other Jira APIs.

I also have code for deleting attachments and uploading a buffer as a new attachment. I can add those if you're interested.

Thanks for creating this! 