### PR TITLE
Make comment display more configurable

### DIFF
--- a/jira-detail.el
+++ b/jira-detail.el
@@ -37,6 +37,14 @@
 (require 'jira-table)
 (require 'jira-utils)
 
+
+(defcustom jira-comments-display-recent-first
+  t
+  "The order to display Jira comments."
+  :type '(choice (const :tag "Newest first" t)
+                 (const :tag "Oldest first" nil))
+  :group 'jira)
+
 ;; they override the default formatters specified
 ;; in jira-issues-fields
 (defvar jira-detail-formatters
@@ -189,7 +197,11 @@
 (defun jira-detail--show-comments (key)
   "Retrieve and display comments for issue KEY."
   (jira-api-call
-   "GET" (format "issue/%s/comment?orderBy=-created" key)
+   "GET" (format "issue/%s/comment?orderBy=%screated"
+                 key
+                 (if jira-comments-display-recent-first
+                     "-"
+                   ""))
    :callback
    (lambda (data _response)
      (jira-detail--comments key (alist-get 'comments data)))))

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -108,22 +108,9 @@ COLOR-TODAY is a boolean to color the date if it is today."
 
 (defun jira-fmt-datetime (date)
   "Format an ISO 8601 date string into a human-readable format."
-  (let* ((parsed-time (parse-time-string date))
-         (year (nth 5 parsed-time))
-         (month (nth 4 parsed-time))
-         (day (nth 3 parsed-time))
-         (hour (nth 2 parsed-time))
-         (minute (nth 1 parsed-time))
-         (second (nth 0 parsed-time))
-         (timezone (if (string-match "\\([+-][0-9]\\{2\\}\\)\\([0-9]\\{2\\}\\)$" date)
-                       (format "UTC%s:%s"
-                               (match-string 1 date)
-                               (match-string 2 date))
-                     "UTC")))
+  (let ((parsed-time (date-to-time date)))
     (propertize
-     (format "%s %d, %d, %02d:%02d:%02d (%s)"
-            (format-time-string "%B" (encode-time second minute hour day month year))
-            day year hour minute second timezone)
+     (format-time-string "%c" parsed-time)
      'face 'jira-face-date)))
 
 (defun jira-fmt-time-from-secs (secs)


### PR DESCRIPTION
My company's Jira server is set for a different timezone than where I live. The API returns comments with timestamps in the server's TZ, but I want to see them in my local format. Maybe this should be configurable between ISO 8601, `strftime("%c")`, and a relative display like "5 minutes ago", "2 days ago" etc. ?

Also, I like to read comments from oldest to most recent. Maybe I'm just old-fashioned 😀 The defcustom defaults to the existing behavior.