### PR TITLE
Display more kinds of markup in comments, descriptions

### DIFF
--- a/jira-doc.el
+++ b/jira-doc.el
@@ -56,6 +56,12 @@
   (let ((marks (alist-get 'marks block)))
     (cl-find-if (lambda (m) (equal m '((type . "strong")))) marks)))
 
+(defun jira-doc--format-mention (block)
+  (let* ((attrs (alist-get 'attrs block))
+         (text (alist-get 'text attrs)))
+    ;; Instead of using text, we could look up the user's info based
+    ;; on the 'id attr.
+    (jira-fmt-mention text)))
 
 (defun jira-doc--format-inline-block(block)
   "Format inline BLOCK to a string."
@@ -65,6 +71,8 @@
           ((string= type "inlineCard")
            (let* ((url (alist-get 'url (alist-get 'attrs block))))
              (buttonize url `(lambda (data) (interactive) (browse-url ,url)))))
+          ((string= type "mention")
+           (jira-doc--format-mention block))
           (text (let ((text-str (format "%s " text)))
 		  (if (jira-doc--is-bold block)
 		      (jira-fmt-bold text-str)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -58,6 +58,16 @@
     ;; on the 'id attr.
     (jira-fmt-mention text)))
 
+(defun jira-doc--format-date (block)
+  "Format BLOCK, a date node, as a string."
+  (let* ((timestamp (alist-get 'timestamp (alist-get 'attrs block)))
+         ;; 32-bit time_t only requires 10 digits but Jira sends 13?
+         (ts (string-to-number (if (= 13 (length timestamp))
+                                   (subseq timestamp 0 10)
+                                 timestamp)))
+         (s (format-time-string "%F" ts t)))
+    (jira-fmt-date s t)))
+
 (defun jira-doc--marks (block)
   "Return a list of mark attributes from BLOCK."
   (let ((m* '()))
@@ -94,6 +104,9 @@
           ((string= type "emoji")
            (let ((text (alist-get 'text (alist-get 'attrs block))))
              (jira-fmt-emoji text)))
+          ((string= type "date")
+           (jira-doc--format-date (alist-get 'timestamp
+                                             (alist-get 'attrs block))))
           (text (let ((marks (jira-doc--marks block)))
                   (jira-fmt-with-marks text marks))))))
 

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -91,6 +91,9 @@
              (buttonize url `(lambda (data) (interactive) (browse-url ,url)))))
           ((string= type "mention")
            (jira-doc--format-mention block))
+          ((string= type "emoji")
+           (let ((text (alist-get 'text (alist-get 'attrs block))))
+             (jira-fmt-emoji text)))
           (text (let ((marks (jira-doc--marks block)))
                   (jira-fmt-with-marks text marks))))))
 

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -91,9 +91,8 @@
              (buttonize url `(lambda (data) (interactive) (browse-url ,url)))))
           ((string= type "mention")
            (jira-doc--format-mention block))
-          (text (let ((text-str (format "%s " text))
-                      (marks (jira-doc--marks block)))
-                  (jira-fmt-with-marks text-str marks))))))
+          (text (let ((marks (jira-doc--marks block)))
+                  (jira-fmt-with-marks text marks))))))
 
 (defvar jira-doc--indent
   0

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -223,6 +223,24 @@ COLOR-TODAY is a boolean to color the date if it is today."
     ;; otherwise, `text' is probably a normal Unicode emoji
     text))
 
+(defun jira-fmt--color (color-hex)
+  "Return a hex color string usable instead of COLOR-HEX on the current frame."
+  ;; This is easier than importing the whole palette, but maybe we
+  ;; should do that?
+  (let* ((crgb (color-name-to-rgb color-hex))
+         (color-to-use (if (and (color-gray-p color-hex)
+                                (color-dark-p crgb))
+                           (color-complement color-hex)
+                         crgb))
+         (hex (lambda (v)
+                (round (* 255 v)))))
+    (pcase color-to-use
+      (`(,r ,g ,b)
+       (format "#%02x%02x%02x"
+               (funcall hex r)
+               (funcall hex g)
+               (funcall hex b))))))
+
 (defun jira-fmt-with-marks (text marks)
   "Format TEXT using MARKS.
 
@@ -237,7 +255,7 @@ See `jira-doc--marks' for the expected format of MARKS."
         (jira-fmt-code text)
       (let* ((face-attrs (mapcan #'(lambda (x)
                                      (pcase x
-                                       (`(color . ,c) `(:foreground ,c))
+                                       (`(color . ,c) `(:foreground ,(jira-fmt--color c)))
                                        ('strong       '(:weight bold))
                                        ('em           '(:slant italic))
                                        ('underline    '(:underline t))

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -42,6 +42,9 @@
 (defface jira-face-time
   '((t :inherit match)) "Face used to show times." :group 'jira)
 
+(defface jira-face-mention
+  '((t :inherit link)) "Face used to show mentions." :group 'jira)
+
 (defface jira-face-success
   '((t (:foreground "#fff" :background "#77AA77")))
   "Face used to show success status." :group 'jira)
@@ -199,6 +202,10 @@ COLOR-TODAY is a boolean to color the date if it is today."
 (defun jira-fmt-code (text)
   "Format TEXT as code, with a monospaced font and a light background."
   (propertize text 'face '(:family "Monospace" :background "#f0f0f0")))
+
+(defun jira-fmt-mention (text)
+  "Format TEXT as a mention."
+  (propertize text 'face 'jira-face-mention))
 
 (provide 'jira-fmt)
 

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -61,6 +61,10 @@
   '((t (:foreground "#fff" :background "#999999")))
   "Face used to show tags." :group 'jira)
 
+(defface jira-face-code
+  '((t (:family "Monospace")))
+  "Face used to show code blocks." :group 'jira)
+
 (defcustom jira-statuses-done '("Done" "Closed" "Waiting for QA")
   "A list of statuses names representing done state."
   :type '(repeat string) :group 'jira)
@@ -200,8 +204,8 @@ COLOR-TODAY is a boolean to color the date if it is today."
   (replace-regexp-in-string "\r\n" "\n" text))
 
 (defun jira-fmt-code (text)
-  "Format TEXT as code, with a monospaced font and a light background."
-  (propertize text 'face '(:family "Monospace" :background "#f0f0f0")))
+  "Format TEXT as code."
+  (propertize text 'face 'jira-face-code))
 
 (defun jira-fmt-mention (text)
   "Format TEXT as a mention."

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -45,6 +45,11 @@
 (defface jira-face-mention
   '((t :inherit link)) "Face used to show mentions." :group 'jira)
 
+(defface jira-face-emoji-reference
+  '((t :inherit font-lock-builtin-face))
+  "Face used to show non-standard Jira emoji references."
+  :group 'jira)
+
 (defface jira-face-success
   '((t (:foreground "#fff" :background "#77AA77")))
   "Face used to show success status." :group 'jira)
@@ -210,6 +215,13 @@ COLOR-TODAY is a boolean to color the date if it is today."
 (defun jira-fmt-mention (text)
   "Format TEXT as a mention."
   (propertize text 'face 'jira-face-mention))
+
+(defun jira-fmt-emoji (text)
+  "Format TEXT as an emoji."
+  (if (string-match-p "^:[-a-z_]+:\\'" text)
+      (propertize text 'face 'jira-face-emoji-reference)
+    ;; otherwise, `text' is probably a normal Unicode emoji
+    text))
 
 (defun jira-fmt-with-marks (text marks)
   "Format TEXT using MARKS.


### PR DESCRIPTION
This PR adds support for several kinds of text nodes and marks:

  * numeric labels for `orderedList`s
  * indentation for nested lists
  * user mentions
  * emoji
  * calendar dates
  * italic, underline, strike-through, inline code, super/subscript
  * foreground color, adapting to dark backgrounds
  
I'm not sure about the code in `jira-doc--format-date`. The [documentation](https://developer.atlassian.com/cloud/jira/platform/apis/document/nodes/date/) for date nodes doesn't say what the `timestamp` field is supposed to be. It looks like a Unix `time_t`, but the values I get from the server all look like this:

    ((type . "date")
     (attrs (timestamp . "1745798400000")))
     
i.e., `time_t` × 1000. What does it look like in your setup?