### PR TITLE
fix type error when formatting issues with missing progress data

### DIFF
--- a/jira-issues.el
+++ b/jira-issues.el
@@ -82,7 +82,15 @@ This information is added to worklogs to make it easier to identify")
 (defun jira-issues--data-format-cell (issue field)
   "Format the given FIELD from the given ISSUE."
   (let* ((extracted (jira-table-extract-field jira-issues-fields field issue))
-         (value (or extracted ""))
+         ;; Provide appropriate defaults based on field type instead of always using ""
+         (value (cond
+                 (extracted extracted)
+                 ;; For progress-related fields, default to 0 instead of ""
+                 ((memq field '(:progress-percent :work-ratio)) 0)
+                 ;; For time fields, default to nil instead of ""
+                 ((memq field '(:remaining-time :time-estimate)) nil)
+                 ;; For other fields, keep the original behavior
+                 (t "")))
          (formatter (jira-table-field-formatter jira-issues-fields field)))
     (if formatter (funcall formatter value) (format "%s" value))))
 


### PR DESCRIPTION
Fixes issue where `jira-fmt-issue-progress` receives empty string instead of numeric value, causing `(wrong-type-argument number-or-marker-p "")` error.

**Root Cause**: 
`jira-issues--data-format-cell` was defaulting all missing field values to empty string `""`, but numeric formatters expect numeric types.

**Solution**: 
Provide field-type-aware defaults:
- Progress fields (`:progress-percent`, `:work-ratio`) default to `0`
- Time fields (`:remaining-time`, `:time-estimate`) default to `nil` 
- Other fields maintain original behavior (empty string)

**Reproduces**: When JIRA issues have missing or null progress data (e.g., `total: 0` in progress field)