### PR TITLE
Add "refresh" binding for jira-detail-mode.

### DIFF
--- a/jira-detail.el
+++ b/jira-detail.el
@@ -367,6 +367,11 @@
     (define-key map (kbd "c")
      (lambda () (interactive)
        (jira-actions-copy-issues-id-to-clipboard jira-detail--current-key)))
+    (define-key map (kbd "g")
+     (lambda ()
+       "Refresh the current issue detail buffer."
+       (interactive)
+       (jira-detail-show-issue jira-detail--current-key)))
     (define-key map (kbd "O")
      (lambda () (interactive) (jira-actions-open-issue jira-detail--current-key)))
     map)


### PR DESCRIPTION
The default binding for `revert-buffer` works in the issue summary, but for the issue detail mode we need something that uses the issue key.