### PR TITLE
Add ability to add/remove watchers on an issue

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Changelog
+## 2.5.0 (2025-07-21)
+- Add ability to add/remove watchers on an issue
 
 ## 2.4.0 (2025-07-19)
 - Add support for favorite JQL filters.

--- a/jira-actions.el
+++ b/jira-actions.el
@@ -35,6 +35,7 @@
 (require 'jira-doc)
 (require 'jira-tempo)
 (require 'jira-utils)
+(require 'jira-users)
 
 (defun jira-actions--marked-issue-description ()
   "Get the description of the marked issue from `jira-issues-key-summary-map'."
@@ -173,6 +174,30 @@
   (when issue-key
     (kill-new issue-key)
     (message "Copied issue ID: %s" issue-key)))
+
+(defun jira-actions-add-watcher (issue-key callback)
+  "Add a user as a watcher to ISSUE-KEY."
+  (pcase (jira-users-read-user "Add watcher: ")
+    (`(,name ,id)
+     (jira-api-call "POST"
+                    (format "issue/%s/watchers" issue-key)
+                    :data id
+                    :callback
+                    (lambda (_data _response)
+                      (message "Added %s as a watcher." name)
+                      (funcall callback))))))
+
+(defun jira-actions-remove-watcher (issue-key watchers callback)
+  "Remove a user as a watcher to ISSUE-KEY."
+  (pcase (jira-users-read-user "Remove watcher: " watchers)
+    (`(,name ,id)
+     (jira-api-call "DELETE"
+                    (format "issue/%s/watchers" issue-key)
+                    :params `(("accountId" . ,id))
+                    :callback
+                    (lambda (_data _response)
+                      (message "Removed %s as a watcher." name)
+                      (funcall callback))))))
 
 (provide 'jira-actions)
 

--- a/jira-users.el
+++ b/jira-users.el
@@ -1,12 +1,8 @@
-;;; jira.el --- Emacs Interface to Jira  -*- lexical-binding: t -*-
+;;; jira-users.el --- Jira user database             -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2025 Pablo González Carrizo
+;; Copyright (C) 2025  Dan McCarthy
 
-;; Author: Pablo González Carrizo <unmonoqueteclea@gmail.com>
-;; Version: 2.5.0
-;; Created: 2025-02-16
-;; URL: https://github.com/unmonoqueteclea/jira.el
-;; Package-Requires: ((emacs "29.1") (request "0.3.0") (tablist "1.0") (transient "0.8.3") (magit-section "4.2.0"))
+;; Author: Dan McCarthy <daniel.c.mccarthy@gmail.com>
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -27,15 +23,22 @@
 
 ;;; Commentary:
 
-;; This package allows you to visualuze and manipulate Jira issues from Emacs.
-
 ;;; Code:
 
-(require 'jira-issues)
-(require 'jira-tempo)
+(require 'jira-api)
 
-(defconst jira-version "jira.el v2.5.0" "jira.el package version.")
+;; jira-users hash table is retrieved within jira-api
 
-(provide 'jira)
+(defun jira-users-read-user (prompt &optional watchers)
+  "Complete a Jira username with PROMPT.
 
-;;; jira.el ends here
+Returns a list: (NAME ACCOUNT-ID). WATCHERS is an optional list of
+display names to complete from; the default is all names in
+`jira-users'."
+  (let* ((name (completing-read prompt (or watchers jira-users)))
+         (account-id (gethash name jira-users)))
+    (list name account-id)))
+
+(provide 'jira-users)
+
+;;; jira-users.el ends here

--- a/readme.md
+++ b/readme.md
@@ -160,6 +160,7 @@ This is the list of customizations you can set:
    - ⚠️ Some Jira instances only allow REST API version 2
 - `jira-tempo-token`: Jira [tempo.io](https://www.tempo.io/) API token
 - `jira-debug`: Whether to log jira.el internal processes data, including API responses
+- `jira-users-max-results`:  Maximum number of Jira usernames to retrieve (default: `1000`)
 - `jira-issues-table-fields`: Fields to show in the issues table.
    Allowed values are defined in `jira-issues-fields`. Example: `'(:key :issue-type-name :status-name :assignee-name :progress-percent :work-ratio :remaining-time :summary)`
 - `jira-issues-max-results`: Maximum number of Jira issues to retrieve


### PR DESCRIPTION
In `jira-detail-mode`, `w` pops up a transient with commands for adding or removing a user from the watchers list. To make that easier to use, I also added a table mapping Jira display names to account IDs. Now we can offer completion when prompting for a user name.

It's not the best to have the watchers commands in a nested transient. There's plenty of room left in `jira-detail--actions-menu`. I originally wanted to use two-letter commands `w +` and `w -`, but those don't work for the major mode. So using a nested transient bound to `w` means at least the complete key sequences are the same.

In my testing, adding watchers works, but removing fails with 403 every time. I can remove watchers on the web page, so I definitely have the correct permissions, and I'm pretty sure the code is correct. Let me know if you have any ideas!