### PR TITLE
Syntax highlighting for jira-comment-mode

### DIFF
--- a/jira-comment.el
+++ b/jira-comment.el
@@ -52,17 +52,17 @@
     (,(rx "~" (+? not-newline) "~")
      0 'font-lock-builtin-face prepend)))
 
-(defvar jira-regexp-link
+(defconst jira-regexp-link
   (rx "[" (submatch (*? (not "]"))) "]"))
 
-(defvar jira-regexp-code
+(defconst jira-regexp-code
   (rx (or (seq "`" (submatch-n 1 (*? (not "`"))) "`")
           (seq "{{" (submatch-n 1 (*? (not "}"))) "}}"))))
 
-(defvar jira-regexp-mention
+(defconst jira-regexp-mention
   (rx "[~" (submatch (*? (not "]"))) "]"))
 
-(defvar jira-regexp-emoji
+(defconst jira-regexp-emoji
   (rx ":" (submatch (+ (or lower digit "-"))) ":"))
 
 (defvar jira-inline-block-keywords
@@ -71,16 +71,16 @@
     (,jira-regexp-code . 'jira-face-code)
     (,jira-regexp-emoji 0 'jira-face-emoji-reference prepend)))
 
-(defvar jira-regexp-blockquote
+(defconst jira-regexp-blockquote
   (rx bol "bq. " (submatch (+ not-newline))))
 
-(defvar jira-regexp-heading
+(defconst jira-regexp-heading
   (rx bol "h" (submatch (any "1-6") ". " (*? not-newline)) eol))
 
-(defvar jira-regexp-hr
+(defconst jira-regexp-hr
   (rx bol "----"))
 
-(defvar jira-regexp-list-item
+(defconst jira-regexp-list-item
   (rx bol
       (submatch (+ (or "*" "#" "-")))
       (+ space)
@@ -107,7 +107,7 @@
     (,(rx bol "h6. " (*? not-newline) eol)
      . 'jira-face-h6)))
 
-(defvar jira-regexp-comment-instruction
+(defconst jira-regexp-comment-instruction
   (rx bol (+ ";") (+? not-newline) eol))
 
 (defvar jira-font-lock-keywords

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -53,7 +53,13 @@
     (,(rx bow "-" (+? (not "-")) "-")
      0 'jira-face-deleted prepend)
     (,(rx "+" (+? not-newline) "+")
-     0 'jira-face-inserted prepend)))
+     0 'jira-face-inserted prepend)
+    ;; can't display subscript or superscript: AFAICT font-lock
+    ;; shouldn't manage the 'display text property.
+    (,(rx "^" (+? not-newline) "^")
+     0 'font-lock-builtin-face prepend)
+    (,(rx "~" (+? not-newline) "~")
+     0 'font-lock-builtin-face prepend)))
 
 (defvar jira-link-regexp
   (rx "[" (submatch (*? (not "]"))) "]"))

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -77,6 +77,9 @@
 (defvar jira-regexp-heading
   (rx bol "h" (submatch (any "1-6") ". " (*? not-newline)) eol))
 
+(defvar jira-regexp-hr
+  (rx bol "----"))
+
 (defvar jira-block-keywords
   `((,jira-regexp-blockquote
      0 'jira-face-blockquote prepend)

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -52,37 +52,37 @@
     (,(rx "~" (+? not-newline) "~")
      0 'font-lock-builtin-face prepend)))
 
-(defvar jira-link-regexp
+(defvar jira-regexp-link
   (rx "[" (submatch (*? (not "]"))) "]"))
 
-(defvar jira-code-regexp
+(defvar jira-regexp-code
   (rx (or (seq "`" (submatch-n 1 (*? (not "`"))) "`")
           (seq "{{" (submatch-n 1 (*? (not "}"))) "}}"))))
 
-(defvar jira-mention-regexp
+(defvar jira-regexp-mention
   (rx "[~" (submatch (*? (not "]"))) "]"))
 
-(defvar jira-emoji-regexp
+(defvar jira-regexp-emoji
   (rx ":" (submatch (+ (or lower digit "-"))) ":"))
 
 (defvar jira-inline-block-keywords
-  `((,jira-mention-regexp . 'jira-face-mention)
-    (,jira-link-regexp . 'jira-face-link)
-    (,jira-code-regexp . 'jira-face-code)
-    (,jira-emoji-regexp 0 'jira-face-emoji-reference prepend)))
+  `((,jira-regexp-mention . 'jira-face-mention)
+    (,jira-regexp-link . 'jira-face-link)
+    (,jira-regexp-code . 'jira-face-code)
+    (,jira-regexp-emoji 0 'jira-face-emoji-reference prepend)))
 
-(defvar jira-blockquote-regexp
+(defvar jira-regexp-blockquote
   (rx bol "bq. " (submatch (+ not-newline))))
 
-(defvar jira-heading-regexp
+(defvar jira-regexp-heading
   (rx bol "h" (submatch (any "1-6") ". " (*? not-newline)) eol))
 
 (defvar jira-block-keywords
-  `((,jira-blockquote-regexp
+  `((,jira-regexp-blockquote
      0 'jira-face-blockquote prepend)
     (,(rx bol (submatch (+ (or "*" "#" "-"))) " ")
      . font-lock-builtin-face)
-    ;; can't use `jira-heading-regexp' because font-lock can't select
+    ;; can't use `jira-regexp-heading' because font-lock can't select
     ;; a face based on the contents of the match.
     (,(rx bol "h1. " (*? not-newline) eol)
      . 'jira-face-h1)

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -17,13 +17,7 @@
   :group 'jira)
 
 (defvar jira-mark-keywords
-  `((,(rx "[" (*? (not "]")) "]")
-     . 'jira-face-link)
-    (,(rx "{{" (*? (not "}")) "}}")
-     . 'jira-face-code)
-    (,(rx "`" (+? (not "`")) "`")
-     . 'jira-face-code)
-    (,(rx bow "*" (+? not-newline) "*" eow)
+  `((,(rx bow "*" (+? not-newline) "*" eow)
      0 'bold prepend)
     (,(rx bow "_" (+? not-newline) "_" eow)
      0 'italic prepend)
@@ -32,13 +26,28 @@
     (,(rx "+" (+? not-newline) "+")
      0 'jira-face-inserted prepend)))
 
+(defvar jira-link-regexp
+  (rx "[" (submatch (*? (not "]"))) "]"))
+
+(defvar jira-code-regexp
+  (rx (or (seq "`" (submatch-n 1 (*? (not "`"))) "`")
+          (seq "{{" (submatch-n 1 (*? (not "}"))) "}}"))))
+
+(defvar jira-mention-regexp
+  (rx "[~" (submatch (*? (not "]"))) "]"))
+
+(defvar jira-emoji-regexp
+  (rx ":" (submatch (+ (or lower digit "-"))) ":"))
+
+(defvar jira-inline-block-keywords
+  `((,jira-mention-regexp . 'jira-face-mention)
+    (,jira-link-regexp . 'jira-face-link)
+    (,jira-code-regexp . 'jira-face-code)
+    (,jira-emoji-regexp 0 'jira-face-emoji-reference prepend)))
+
 (defvar jira-block-keywords
-  `((,(rx "[~" (*? (not "]")) "]")
-     . 'jira-face-mention)
-    (,(rx "bq. " (+ not-newline))
+  `((,(rx "bq. " (+ not-newline))
      0 'jira-face-blockquote prepend)
-    (,(rx ":" (+ (or lower digit "-")) ":")
-     0 'jira-face-emoji-reference prepend)
     (,(rx bol (submatch (+ (or "*" "#" "-"))) " ")
      . font-lock-builtin-face)
     (,(rx bol "h1. " (*? not-newline) eol)
@@ -56,13 +65,11 @@
 
 (defvar jira-font-lock-keywords
   (append jira-block-keywords
+          jira-inline-block-keywords
           jira-mark-keywords))
 
 (defvar jira-marks-delimiters
-  `(("`"  "`"  code)
-    ("{{" "}}" code)
-    ("_"  "_"  em)
-    ("["  "]"  link)
+  `(("_"  "_"  em)
     ("-"  "-"  strike)
     ("*"  "*"  strong)
     ("+"  "+"  underline))

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -31,19 +31,10 @@
   (require 'rx))
 
 (require 'jira-users)
+(require 'jira-fmt)
 
 (defvar-local jira-comment--callback nil
   "The callback function to call after adding a comment.")
-
-(defface jira-face-deleted
-  '((t (:strike-through t)))
-  "Face for Jira deleted markup."
-  :group 'jira)
-
-(defface jira-face-inserted
-  '((t (:underline t)))
-  "Face for Jira inserted markup."
-  :group 'jira)
 
 (defvar jira-mark-keywords
   `((,(rx bow "*" (+? not-newline) "*" eow)

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -80,10 +80,17 @@
 (defvar jira-regexp-hr
   (rx bol "----"))
 
+(defvar jira-regexp-list-item
+  (rx bol
+      (submatch (+ (or "*" "#" "-")))
+      (+ space)
+      (submatch (+? not-newline))
+      eol))
+
 (defvar jira-block-keywords
   `((,jira-regexp-blockquote
      0 'jira-face-blockquote prepend)
-    (,(rx bol (submatch (+ (or "*" "#" "-"))) " ")
+    (,jira-regexp-list-item
      . font-lock-builtin-face)
     ;; can't use `jira-regexp-heading' because font-lock can't select
     ;; a face based on the contents of the match.

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -1,5 +1,32 @@
 ;;; jira-comment.el --- Writing comments  -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2025 Dan McCarthy, Pablo González Carrizo
+
+;; Author: Dan McCarthy <daniel.c.mccarthy@gmail.com>
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; Edit comments/descriptions with font-lock support.
+;; Markup taken from https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa?section=all
+
+;;; Code:
 (eval-when-compile
   (require 'rx))
 
@@ -75,6 +102,13 @@
     ("+"  "+"  underline))
   "List matching the start of a group of text marks.")
 
+(defvar-keymap jira-comment-mode-map
+  "C-c C-c" #'(lambda ()
+                "Send the buffer contents to Jira."
+                (interactive)
+                (funcall jira-comment--callback))
+  "C-c C-k" 'kill-buffer)
+
 (define-derived-mode jira-comment-mode text-mode
   "Jira Comment"
   "Major mode for writing Jira comments."
@@ -87,15 +121,7 @@
                       (modify-syntax-entry ?{ "w" st)
                       (modify-syntax-entry ?} "w" st)
                       st))
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-c")
-                (lambda ()
-                  (interactive)
-                  (funcall jira-comment--callback)))
-    (define-key map (kbd "C-c C-k")
-                (lambda () (interactive) (kill-buffer buf)))
-    (set-buffer-modified-p nil)
-    (use-local-map map)))
+  (set-buffer-modified-p nil))
 
 (defun jira-comment-create-editor-buffer
     (buffer-name initial-content instructions save-callback)
@@ -116,3 +142,5 @@
       (select-window (get-buffer-window buf)))))
 
 (provide 'jira-comment)
+
+;;; jira-comment.el ends here

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -80,11 +80,19 @@
     (,jira-code-regexp . 'jira-face-code)
     (,jira-emoji-regexp 0 'jira-face-emoji-reference prepend)))
 
+(defvar jira-blockquote-regexp
+  (rx bol "bq. " (submatch (+ not-newline))))
+
+(defvar jira-heading-regexp
+  (rx bol "h" (submatch (any "1-6") ". " (*? not-newline)) eol))
+
 (defvar jira-block-keywords
-  `((,(rx "bq. " (+ not-newline))
+  `((,jira-blockquote-regexp
      0 'jira-face-blockquote prepend)
     (,(rx bol (submatch (+ (or "*" "#" "-"))) " ")
      . font-lock-builtin-face)
+    ;; can't use `jira-heading-regexp' because font-lock can't select
+    ;; a face based on the contents of the match.
     (,(rx bol "h1. " (*? not-newline) eol)
      . 'jira-face-h1)
     (,(rx bol "h2. " (*? not-newline) eol)

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -16,10 +16,8 @@
   "Face for Jira inserted markup."
   :group 'jira)
 
-(defvar jira-font-lock-keywords
-  `((,(rx "[~" (*? (not "]")) "]")
-     . 'jira-face-mention)
-    (,(rx "[" (*? (not "]")) "]")
+(defvar jira-mark-keywords
+  `((,(rx "[" (*? (not "]")) "]")
      . 'jira-face-link)
     (,(rx "{{" (*? (not "}")) "}}")
      . 'jira-face-code)
@@ -32,7 +30,11 @@
     (,(rx bow "-" (+? (not "-")) "-")
      0 'jira-face-deleted prepend)
     (,(rx "+" (+? not-newline) "+")
-     0 'jira-face-inserted prepend)
+     0 'jira-face-inserted prepend)))
+
+(defvar jira-block-keywords
+  `((,(rx "[~" (*? (not "]")) "]")
+     . 'jira-face-mention)
     (,(rx "bq. " (+ not-newline))
      0 'jira-face-blockquote prepend)
     (,(rx ":" (+ (or lower digit "-")) ":")
@@ -51,6 +53,20 @@
      . 'jira-face-h5)
     (,(rx bol "h6. " (*? not-newline) eol)
      . 'jira-face-h6)))
+
+(defvar jira-font-lock-keywords
+  (append jira-block-keywords
+          jira-mark-keywords))
+
+(defvar jira-marks-delimiters
+  `(("`"  "`"  code)
+    ("{{" "}}" code)
+    ("_"  "_"  em)
+    ("["  "]"  link)
+    ("-"  "-"  strike)
+    ("*"  "*"  strong)
+    ("+"  "+"  underline))
+  "List matching the start of a group of text marks.")
 
 (define-derived-mode jira-comment-mode text-mode
   "Jira Comment"

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -30,6 +30,8 @@
 (eval-when-compile
   (require 'rx))
 
+(require 'jira-users)
+
 (defvar-local jira-comment--callback nil
   "The callback function to call after adding a comment.")
 
@@ -102,12 +104,20 @@
     ("+"  "+"  underline))
   "List matching the start of a group of text marks.")
 
+(defun jira-comment-insert-mention ()
+  "Insert a mention at point, prompting for a username."
+  (interactive)
+  (pcase (jira-users-read-user "Mention user: ")
+    (`(,name ,_id)
+     (insert (concat "[~" name "]")))))
+
 (defvar-keymap jira-comment-mode-map
   "C-c C-c" #'(lambda ()
                 "Send the buffer contents to Jira."
                 (interactive)
                 (funcall jira-comment--callback))
-  "C-c C-k" 'kill-buffer)
+  "C-c C-k" 'kill-buffer
+  "C-c m"   'jira-comment-insert-mention)
 
 (define-derived-mode jira-comment-mode text-mode
   "Jira Comment"

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -1,0 +1,95 @@
+;;; jira-comment.el --- Writing comments  -*- lexical-binding: t; -*-
+
+(eval-when-compile
+  (require 'rx))
+
+(defvar-local jira-comment--callback nil
+  "The callback function to call after adding a comment.")
+
+(defface jira-face-deleted
+  '((t (:strike-through t)))
+  "Face for Jira deleted markup."
+  :group 'jira)
+
+(defface jira-face-inserted
+  '((t (:underline t)))
+  "Face for Jira inserted markup."
+  :group 'jira)
+
+(defvar jira-font-lock-keywords
+  `((,(rx "[~" (*? (not "]")) "]")
+     . 'jira-face-mention)
+    (,(rx "[" (*? (not "]")) "]")
+     . 'jira-face-link)
+    (,(rx "{{" (*? (not "}")) "}}")
+     . 'jira-face-code)
+    (,(rx "`" (+? (not "`")) "`")
+     . 'jira-face-code)
+    (,(rx bow "*" (+? not-newline) "*" eow)
+     0 'bold prepend)
+    (,(rx bow "_" (+? not-newline) "_" eow)
+     0 'italic prepend)
+    (,(rx bow "-" (+? (not "-")) "-")
+     0 'jira-face-deleted prepend)
+    (,(rx "+" (+? not-newline) "+")
+     0 'jira-face-inserted prepend)
+    (,(rx "bq. " (+ not-newline))
+     0 'jira-face-blockquote prepend)
+    (,(rx ":" (+ (or lower digit "-")) ":")
+     0 'jira-face-emoji-reference prepend)
+    (,(rx bol (submatch (+ (or "*" "#" "-"))) " ")
+     . font-lock-builtin-face)
+    (,(rx bol "h1. " (*? not-newline) eol)
+     . 'jira-face-h1)
+    (,(rx bol "h2. " (*? not-newline) eol)
+     . 'jira-face-h2)
+    (,(rx bol "h3. " (*? not-newline) eol)
+     . 'jira-face-h3)
+    (,(rx bol "h4. " (*? not-newline) eol)
+     . 'jira-face-h4)
+    (,(rx bol "h5. " (*? not-newline) eol)
+     . 'jira-face-h5)
+    (,(rx bol "h6. " (*? not-newline) eol)
+     . 'jira-face-h6)))
+
+(define-derived-mode jira-comment-mode text-mode
+  "Jira Comment"
+  "Major mode for writing Jira comments."
+  (setq font-lock-defaults '(jira-font-lock-keywords))
+  (set-syntax-table (let ((st (make-syntax-table)))
+                      (modify-syntax-entry ?+ "w" st)
+                      (modify-syntax-entry ?* "w" st)
+                      (modify-syntax-entry ?_ "w" st)
+                      (modify-syntax-entry ?- "w" st)
+                      (modify-syntax-entry ?{ "w" st)
+                      (modify-syntax-entry ?} "w" st)
+                      st))
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c")
+                (lambda ()
+                  (interactive)
+                  (funcall jira-comment--callback)))
+    (define-key map (kbd "C-c C-k")
+                (lambda () (interactive) (kill-buffer buf)))
+    (set-buffer-modified-p nil)
+    (use-local-map map)))
+
+(defun jira-comment-create-editor-buffer
+    (buffer-name initial-content instructions save-callback)
+  "Create and display an editor buffer with INITIAL-CONTENT and a SAVE-CALLBACK."
+  (let ((buf (get-buffer-create buffer-name)))
+    (with-current-buffer buf
+      (erase-buffer)
+      (insert instructions "\n\n")
+      (insert initial-content)
+      (jira-comment-mode)
+      (setq jira-comment--callback
+            (lambda ()
+              (let ((content (buffer-string)))
+                (kill-buffer buf)
+                (funcall save-callback
+		         (string-trim (string-remove-prefix instructions content))))))
+      (display-buffer buf)
+      (select-window (get-buffer-window buf)))))
+
+(provide 'jira-comment)

--- a/jira-comment.el
+++ b/jira-comment.el
@@ -97,13 +97,6 @@
           jira-inline-block-keywords
           jira-mark-keywords))
 
-(defvar jira-marks-delimiters
-  `(("_"  "_"  em)
-    ("-"  "-"  strike)
-    ("*"  "*"  strong)
-    ("+"  "+"  underline))
-  "List matching the start of a group of text marks.")
-
 (defun jira-comment-insert-mention ()
   "Insert a mention at point, prompting for a username."
   (interactive)

--- a/jira-detail.el
+++ b/jira-detail.el
@@ -39,6 +39,7 @@
 (require 'jira-table)
 (require 'jira-utils)
 (require 'jira-complete)
+(require 'jira-comment)
 
 
 (defvar-local jira-detail--current nil
@@ -52,12 +53,6 @@
 
 (defvar-local jira-detail--current-watchers nil
   "Watchers of the current issue being displayed.")
-
-(defvar-local jira-comment--issue-key nil
-  "The key of the Jira issue for which a comment is being added.")
-
-(defvar-local jira-comment--callback nil
-  "The callback function to call after adding a comment.")
 
 (defconst jira-detail--updatable-fields
   (list (cons "Parent Issue" "parent")
@@ -241,32 +236,9 @@
     (jira-detail--show-other key)
     (pop-to-buffer (current-buffer))))
 
-
-(defun jira-detail--create-editor-buffer
-    (buffer-name initial-content instructions save-callback)
-  "Create and display an editor buffer with INITIAL-CONTENT and a SAVE-CALLBACK."
-  (let ((buf (get-buffer-create buffer-name)))
-    (with-current-buffer buf
-      (erase-buffer)
-      (insert instructions "\n\n")
-      (insert initial-content)
-      (let ((map (make-sparse-keymap)))
-        (define-key map (kbd "C-c C-c")
-          (lambda () (interactive)
-            (let ((content (buffer-string)))
-              (kill-buffer buf)
-              (funcall save-callback
-		       (string-trim (string-remove-prefix instructions content))))))
-        (define-key map (kbd "C-c C-k")
-          (lambda () (interactive) (kill-buffer buf)))
-        (set-buffer-modified-p nil)
-        (use-local-map map))
-      (display-buffer buf)
-      (select-window (get-buffer-window buf)))))
-
 (defun jira-detail--add-comment (key)
   "Add a comment to the issue with KEY."
-  (jira-detail--create-editor-buffer
+  (jira-comment-create-editor-buffer
    (format "*Jira Comment: %s*" key)
    "" jira-comment-instruction-line
    (lambda (content)
@@ -277,7 +249,7 @@
 (defun jira-detail--edit-description-and-update ()
   "Open a buffer to edit the description and update the issue."
   (let ((key jira-detail--current-key))
-    (jira-detail--create-editor-buffer
+    (jira-comment-create-editor-buffer
      (concat "*Jira Description [" key "]*")
      ""
      jira-description-instruction-line

--- a/jira-detail.el
+++ b/jira-detail.el
@@ -75,14 +75,6 @@
 	(cons "Cost Center" (cons :custom "Cost center")))
   "List of fields that can be updated in the Jira detail view.")
 
-(defconst jira-comment-instruction-line
-  ";; Write your comment below - Press C-c C-c to send or C-c C-k to cancel."
-  "The instruction line shown in Jira comment buffers.")
-
-(defconst jira-description-instruction-line
-  ";; Write the description below - Press C-c C-c to save or C-c C-k to cancel."
-  "The instruction line shown in Jira description editor buffers.")
-
 (defcustom jira-comments-display-recent-first
   t
   "The order to display Jira comments."
@@ -240,7 +232,7 @@
   "Add a comment to the issue with KEY."
   (jira-comment-create-editor-buffer
    (format "*Jira Comment: %s*" key)
-   "" jira-comment-instruction-line
+   ""
    (lambda (content)
      (jira-actions-add-comment
       key content
@@ -252,7 +244,6 @@
     (jira-comment-create-editor-buffer
      (concat "*Jira Description [" key "]*")
      ""
-     jira-description-instruction-line
      (lambda (new-description)
        (jira-detail--update-field-action
 	"description" (jira-doc-build new-description) key)))))

--- a/jira-detail.el
+++ b/jira-detail.el
@@ -39,7 +39,7 @@
 (require 'jira-table)
 (require 'jira-utils)
 (require 'jira-complete)
-(require 'jira-comment)
+(require 'jira-edit)
 
 
 (defvar-local jira-detail--current nil
@@ -230,7 +230,7 @@
 
 (defun jira-detail--add-comment (key)
   "Add a comment to the issue with KEY."
-  (jira-comment-create-editor-buffer
+  (jira-edit-create-editor-buffer
    (format "*Jira Comment: %s*" key)
    ""
    (lambda (content)
@@ -241,7 +241,7 @@
 (defun jira-detail--edit-description-and-update ()
   "Open a buffer to edit the description and update the issue."
   (let ((key jira-detail--current-key))
-    (jira-comment-create-editor-buffer
+    (jira-edit-create-editor-buffer
      (concat "*Jira Description [" key "]*")
      ""
      (lambda (new-description)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -368,15 +368,15 @@ NAME should be a username defined in `jira-users'."
 (defun jira-doc--build-code-block (body)
   "Make an ADF codeBlock node."
   `(("type" . "codeBlock")
-    ("content" .
-     (,(jira-doc--build-text (string-trim body))))))
+    ("content"
+     ,(jira-doc--build-text (string-trim body)))))
 
 (defun jira-doc--build-blockquote (quoted-text)
   `(("type" . "blockquote")
-    ("content" .
+    ("content"
      (("type" . "paragraph")
-      ("content" .
-       ,(jira-doc-build-inline-blocks quoted-text))))))
+      ("content"
+       ,@(jira-doc-build-inline-blocks quoted-text))))))
 
 (defun jira-doc--build-heading (heading-text)
   "Make an ADF heading node."
@@ -385,8 +385,8 @@ NAME should be a username defined in `jira-users'."
     `(("type" . "heading")
       ("attrs" .
        (("level" . ,(- level ?0))))
-      ("content" .
-       ,(jira-doc-build-inline-blocks content)))))
+      ("content"
+       ,@(jira-doc-build-inline-blocks content)))))
 
 (defun jira-doc--build-rule ()
   `(("type" . "rule")))

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -297,13 +297,13 @@ which do not match are returned as-is."
 
 (defun jira-doc--build-marked-text (text)
   "Split TEXT into a list of ADF text nodes with marks."
-  (let* ((mark-regexp (concat "\\("
+  (let* ((mark-regexp (concat "\\_<\\("
                               (string-join (mapcar #'(lambda (d)
                                                        (let ((delim (regexp-quote (car d))))
                                                          (concat delim ".+?" delim)))
                                                    jira-doc--marks-delimiters)
                                            "\\|")
-                              "\\)"))
+                              "\\)\\_>"))
          (areas (jira-doc--split (list text)
                                  mark-regexp
                                  #'(lambda (s)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -413,11 +413,11 @@ NAME should be a username defined in `jira-users'."
     ;; structure is not like other marks, so it's easier to pretend
     ;; they're blocks.
     (setq blocks (jira-doc--split blocks
-                                  jira-regexp-link
-                                  #'jira-doc--build-link))
-    (setq blocks (jira-doc--split blocks
                                   jira-regexp-code
                                   #'jira-doc--build-code))
+    (setq blocks (jira-doc--split blocks
+                                  jira-regexp-link
+                                  #'jira-doc--build-link))
     (setq blocks (jira-doc--split blocks
                                   jira-regexp-emoji
                                   #'jira-doc--build-emoji))

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -370,6 +370,9 @@ NAME should be a username defined in `jira-users'."
       ("content" .
        ,(jira-doc-build-inline-blocks content)))))
 
+(defun jira-doc--build-rule ()
+  `(("type" . "rule")))
+
 (defun jira-doc-build-inline-blocks (text)
   "Parse inline block nodes out of TEXT and convert everything to ADF nodes."
   (let ((blocks (jira-doc--split (list text)
@@ -401,6 +404,9 @@ NAME should be a username defined in `jira-users'."
     (setq blocks (jira-doc--split blocks
                                   jira-regexp-heading
                                   #'jira-doc--build-heading))
+    (setq blocks (jira-doc--split blocks
+                                  jira-regexp-hr
+                                  #'jira-doc--build-rule))
     (mapcan (lambda (s)
               (if (stringp s)
                   (jira-doc-build-inline-blocks s)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -466,7 +466,7 @@ NAME should be a username defined in `jira-users'."
                     `(("type" . "paragraph")
                       ;; The documentation for listItem says it doesn't support marks,
                       ;; but empirically it does, so let's interpret them.
-                      ("content" . ,(jira-doc--build-marked-text text)))))
+                      ("content" . ,(jira-doc-build-inline-blocks text)))))
                (depth (+ (length stack)
                          (if cur 1 0))))
            (cond ((> depth d)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -507,7 +507,7 @@ NAME should be a username defined in `jira-users'."
 
 (defun jira-doc-build-toplevel-blocks (text)
   "Parse toplevel blocks out of TEXT and convert to ADF nodes."
-  (let ((blocks (jira-doc--split (list text)
+  (let ((blocks (jira-doc--split text
                                  jira-regexp-blockquote
                                  #'jira-doc--build-blockquote)))
     (setq blocks (jira-doc--split blocks
@@ -517,10 +517,11 @@ NAME should be a username defined in `jira-users'."
                                   jira-regexp-hr
                                   #'jira-doc--build-rule))
     (setq blocks (jira-doc-build-lists blocks))
-    (mapcan (lambda (s)
+    (mapcar (lambda (s)
               (if (stringp s)
-                  (jira-doc-build-inline-blocks s)
-                (list s)))
+                  `(("type" . "paragraph")
+                    ("content" ,@(jira-doc-build-inline-blocks s)))
+                s))
             blocks)))
 
 (defun jira-doc-build (text)
@@ -528,10 +529,7 @@ NAME should be a username defined in `jira-users'."
   (let* ((lines (split-string (or text "") "\n" t)))
     `(("type" . "doc") ("version" . 1)
       ("content" .
-       ,(mapcar (lambda (line)
-                  `(("type" . "paragraph")
-                    ("content" ,@(jira-doc-build-toplevel-blocks line))))
-                lines)))))
+       ,(jira-doc-build-toplevel-blocks lines)))))
 
 (provide 'jira-doc)
 

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -526,10 +526,13 @@ NAME should be a username defined in `jira-users'."
 
 (defun jira-doc-build (text)
   "Build a simple Jira document (ADF) from TEXT."
-  (let* ((lines (split-string (or text "") "\n" t)))
+  (let* ((paras (mapcar #'string-trim
+                        (split-string (or text "")
+                                      "\n\\([ 	]*\n\\)+"
+                                      t))))
     `(("type" . "doc") ("version" . 1)
       ("content" .
-       ,(jira-doc-build-toplevel-blocks lines)))))
+       ,(jira-doc-build-toplevel-blocks paras)))))
 
 (provide 'jira-doc)
 

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -373,19 +373,19 @@ NAME should be a username defined in `jira-users'."
 (defun jira-doc-build-inline-blocks (text)
   "Parse inline block nodes out of TEXT and convert everything to ADF nodes."
   (let ((blocks (jira-doc--split (list text)
-                                 jira-mention-regexp
+                                 jira-regexp-mention
                                  #'jira-doc--build-mention)))
     ;; links and code are actually kinds of marks, but their ADF
     ;; structure is not like other marks, so it's easier to pretend
     ;; they're blocks.
     (setq blocks (jira-doc--split blocks
-                                  jira-link-regexp
+                                  jira-regexp-link
                                   #'jira-doc--build-link))
     (setq blocks (jira-doc--split blocks
-                                  jira-code-regexp
+                                  jira-regexp-code
                                   #'jira-doc--build-code))
     (setq blocks (jira-doc--split blocks
-                                  jira-emoji-regexp
+                                  jira-regexp-emoji
                                   #'jira-doc--build-emoji))
     (mapcan (lambda (s)
               (if (stringp s)
@@ -396,10 +396,10 @@ NAME should be a username defined in `jira-users'."
 (defun jira-doc-build-toplevel-blocks (text)
   "Parse toplevel blocks out of TEXT and convert to ADF nodes."
   (let ((blocks (jira-doc--split (list text)
-                                 jira-blockquote-regexp
+                                 jira-regexp-blockquote
                                  #'jira-doc--build-blockquote)))
     (setq blocks (jira-doc--split blocks
-                                  jira-heading-regexp
+                                  jira-regexp-heading
                                   #'jira-doc--build-heading))
     (mapcan (lambda (s)
               (if (stringp s)

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -285,8 +285,9 @@ which do not match are returned as-is."
                     (unless (= i (match-beginning 0))
                       (push (substring s i (match-beginning 0))
                             subs))
-                    (push (apply f (jira-doc--submatches s))
-                           subs)
+                    (save-match-data
+                      (push (apply f (jira-doc--submatches s))
+                            subs))
                     (setq i (match-end 0)))
                   (unless (= i (length s))
                     (push (substring s i) subs))
@@ -363,6 +364,12 @@ NAME should be a username defined in `jira-users'."
   `(("type" . "emoji")
     ("attrs" .
      (("shortName" . ,name)))))
+
+(defun jira-doc--build-code-block (body)
+  "Make an ADF codeBlock node."
+  `(("type" . "codeBlock")
+    ("content" .
+     (,(jira-doc--build-text (string-trim body))))))
 
 (defun jira-doc--build-blockquote (quoted-text)
   `(("type" . "blockquote")
@@ -508,8 +515,11 @@ NAME should be a username defined in `jira-users'."
 (defun jira-doc-build-toplevel-blocks (text)
   "Parse toplevel blocks out of TEXT and convert to ADF nodes."
   (let ((blocks (jira-doc--split text
-                                 jira-regexp-blockquote
-                                 #'jira-doc--build-blockquote)))
+                                 jira-regexp-code-block
+                                 #'jira-doc--build-code-block)))
+    (setq blocks (jira-doc--split blocks
+                                  jira-regexp-blockquote
+                                  #'jira-doc--build-blockquote))
     (setq blocks (jira-doc--split blocks
                                   jira-regexp-heading
                                   #'jira-doc--build-heading))

--- a/jira-doc.el
+++ b/jira-doc.el
@@ -56,7 +56,13 @@
   `(("_" em)
     ("-" strike)
     ("*" strong)
-    ("+" underline))
+    ("+" underline)
+    ("^" (("type" . "subsup")
+          ("attrs" .
+           ("type" . "sup"))))
+    ("~" (("type" . "subsup")
+          ("attrs" .
+           ("type" . "sub")))))
   "List matching the start of a group of text marks.")
 
 (defun jira-doc--list-to-str (items sep)

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -37,19 +37,19 @@
   "The callback function to call after adding a comment.")
 
 (defvar jira-mark-keywords
-  `((,(rx bow "*" (+? not-newline) "*" eow)
+  `((,(rx symbol-start "*" (+? not-newline) "*" symbol-end)
      0 'bold prepend)
-    (,(rx bow "_" (+? not-newline) "_" eow)
+    (,(rx symbol-start "_" (+? not-newline) "_" symbol-end)
      0 'italic prepend)
-    (,(rx bow "-" (+? (not "-")) "-")
+    (,(rx symbol-start "-" (+? not-newline) "-" symbol-end)
      0 'jira-face-deleted prepend)
-    (,(rx "+" (+? not-newline) "+")
+    (,(rx symbol-start "+" (+? not-newline) "+" symbol-end)
      0 'jira-face-inserted prepend)
     ;; can't display subscript or superscript: AFAICT font-lock
     ;; shouldn't manage the 'display text property.
-    (,(rx "^" (+? not-newline) "^")
+    (,(rx symbol-start "^" (+? not-newline) "^" symbol-end)
      0 'font-lock-builtin-face prepend)
-    (,(rx "~" (+? not-newline) "~")
+    (,(rx symbol-start "~" (+? not-newline) "~" symbol-end)
      0 'font-lock-builtin-face prepend)))
 
 (defconst jira-regexp-link

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -1,4 +1,4 @@
-;;; jira-comment.el --- Writing comments  -*- lexical-binding: t; -*-
+;;; jira-edit.el --- Editing text with Jira markup  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2025 Dan McCarthy, Pablo González Carrizo
 
@@ -33,7 +33,7 @@
 (require 'jira-users)
 (require 'jira-fmt)
 
-(defvar-local jira-comment--callback nil
+(defvar-local jira-edit--callback nil
   "The callback function to call after adding a comment.")
 
 (defvar jira-mark-keywords
@@ -117,7 +117,7 @@
           jira-inline-block-keywords
           jira-mark-keywords))
 
-(defvar jira-comment-instructions
+(defvar jira-edit-instructions
   ";; Write your message above. Lines beginning with ;; will be ignored.
 
 ;; C-c C-c: send
@@ -140,26 +140,26 @@
 ;; h1-6. header
 ;; ---- horizontal rule
 "
-  "Instructions included in jira-comment-mode buffers.")
+  "Instructions included in jira-edit-mode buffers.")
 
-(defun jira-comment-insert-mention ()
+(defun jira-edit-insert-mention ()
   "Insert a mention at point, prompting for a username."
   (interactive)
   (pcase (jira-users-read-user "Mention user: ")
     (`(,name ,_id)
      (insert (concat "[~" name "]")))))
 
-(defvar-keymap jira-comment-mode-map
+(defvar-keymap jira-edit-mode-map
   "C-c C-c" #'(lambda ()
                 "Send the buffer contents to Jira."
                 (interactive)
-                (funcall jira-comment--callback))
+                (funcall jira-edit--callback))
   "C-c C-k" 'kill-buffer
-  "C-c m"   'jira-comment-insert-mention)
+  "C-c m"   'jira-edit-insert-mention)
 
-(define-derived-mode jira-comment-mode text-mode
-  "Jira Comment"
-  "Major mode for writing Jira comments."
+(define-derived-mode jira-edit-mode text-mode
+  "Jira Edit"
+  "Major mode for writing Jira comments, descriptions etc."
   (setq font-lock-defaults '(jira-font-lock-keywords))
   (set-syntax-table (let ((st (make-syntax-table)))
                       (modify-syntax-entry ?+ "w" st)
@@ -171,17 +171,17 @@
                       st))
   (set-buffer-modified-p nil))
 
-(defun jira-comment-create-editor-buffer
+(defun jira-edit-create-editor-buffer
     (buffer-name initial-content save-callback)
   "Create and display an editor buffer with INITIAL-CONTENT and a SAVE-CALLBACK."
   (let ((buf (get-buffer-create buffer-name)))
     (with-current-buffer buf
       (erase-buffer)
       (insert initial-content)
-      (insert "\n\n" jira-comment-instructions)
+      (insert "\n\n" jira-edit-instructions)
       (goto-char (point-min))
-      (jira-comment-mode)
-      (setq jira-comment--callback
+      (jira-edit-mode)
+      (setq jira-edit--callback
             (lambda ()
               (let ((content
                      (progn
@@ -194,6 +194,6 @@
       (display-buffer buf)
       (select-window (get-buffer-window buf)))))
 
-(provide 'jira-comment)
+(provide 'jira-edit)
 
-;;; jira-comment.el ends here
+;;; jira-edit.el ends here

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -91,7 +91,7 @@
   `((,jira-regexp-blockquote
      0 'jira-face-blockquote prepend)
     (,jira-regexp-list-item
-     . font-lock-builtin-face)
+     1 font-lock-builtin-face)
     ;; can't use `jira-regexp-heading' because font-lock can't select
     ;; a face based on the contents of the match.
     (,(rx bol "h1. " (*? not-newline) eol)

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -111,7 +111,7 @@
   (rx bol (+ ";") (+? not-newline) eol))
 
 (defconst jira-regexp-code-block
-  (rx bol "{code}" (submatch (* anychar)) "{code}" (*? whitespace) eol))
+  (rx bol "{code}" (submatch (*? anychar)) "{code}" (*? whitespace) eol))
 
 ;; Implementation taken from https://stackoverflow.com/questions/9452615/emacs-is-there-a-clear-example-of-multi-line-font-locking
 (defun jira-edit-font-lock-extend-region ()

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -139,6 +139,18 @@
 ;; bq. blockquote
 ;; h1-6. header
 ;; ---- horizontal rule
+
+;; Bullet lists:
+;; * a
+;; ** b
+;; *** c
+
+;; Ordered lists:
+;; # 1
+;; # 2
+;; ## 2a
+;; ## 2b
+;; ### 2b1
 "
   "Instructions included in jira-edit-mode buffers.")
 

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -67,8 +67,8 @@
 
 (defvar jira-inline-block-keywords
   `((,jira-regexp-mention . 'jira-face-mention)
-    (,jira-regexp-link . 'jira-face-link)
     (,jira-regexp-code . 'jira-face-code)
+    (,jira-regexp-link . 'jira-face-link)
     (,jira-regexp-emoji 0 'jira-face-emoji-reference prepend)))
 
 (defconst jira-regexp-blockquote

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -123,6 +123,16 @@ For example:
   '((t (:family "Monospace")))
   "Face used to show code blocks." :group 'jira)
 
+(defface jira-face-deleted
+  '((t (:strike-through t)))
+  "Face for Jira deleted markup."
+  :group 'jira)
+
+(defface jira-face-inserted
+  '((t (:underline t)))
+  "Face for Jira inserted markup."
+  :group 'jira)
+
 (defun jira-fmt--alist-p (value)
   (and value (listp value) (or (null value) (consp (car value)))))
 


### PR DESCRIPTION
This PR adds font-lock support for highlighting a number of Jira markup types and parsing them into ADF nodes before sending:

* links
* code segments (within a line, not paragraph-size code blocks)
* emoji
* mentions (with completion!)
* text style: bold, italic, underline, strikethrough

Other node types are fontified in the markup but not yet supported in ADF.

It's not ready to merge yet but I wanted to ask for suggestions on some things:

I used [wiki-style](https://jira.atlassian.com/secure/WikiRendererHelpAction.jspa) markup because the v2 API accepts it. But maybe [markdown](https://support.atlassian.com/jira-software-cloud/docs/markdown-and-keyboard-shortcuts/) would be more popular? I don't know if v2 also accepts markdown, but it wouldn't be terrible to have to translate it back to wiki markup for v2 clients.

Either way, I think it would good to give a glossary of the supported markup syntax in the instructions, like how magit does for git-rebase.

We also need keyboard commands for inserting markup like `html-mode` and `markdown-mode`.

Finally, editing existing comments and descriptions isn't possible yet. Right now we can translate ADF into styled text and marked-up text into ADF. To be able to rewrite comments, we need to translate ADF into marked-up text, the opposite of this PR. Maybe we can abstract all the `jira-doc--format-*` functions to generate styled text for viewing or marked-up text for editing, depending on the context.