### PR TITLE
Display tables and media nodes.

### DIFF
--- a/jira-doc.el
+++ b/jira-doc.el
@@ -154,6 +154,26 @@
       (append (list hborder) boxed-lines (list bborder)) "\n")
      "\n")))
 
+(defun jira-doc--format-media-block (block)
+  (let ((media (mapcar (lambda (b)
+                         (let* ((attrs (alist-get 'attrs b))
+                                (type (alist-get 'type attrs))
+                                (id (alist-get 'id attrs))
+                                (collection (alist-get 'collection attrs)))
+                           (if (string= type "link")
+                               (let ((name (alist-get 'alt attrs id))
+                                     (marks (jira-doc--marks block)))
+                                 (jira-fmt-with-marks (concat "<" name ">") marks))
+                             (jira-fmt-placeholder (format "<file:%s%s>"
+                                                           (if (string= "" collection)
+                                                               ""
+                                                             (concat collection ":"))
+                                                           id)))))
+                       (alist-get 'content block))))
+  (concat
+   "\n"
+   (string-join media "\n"))))
+
 (defun jira-doc--format-content-block(block)
   "Format content BLOCK to a string."
   (let* ((type (alist-get 'type block))
@@ -177,6 +197,9 @@
     (cond
      ((string= type "table")
       "\n<TABLES NOT SUPPORTED BY jira.el>\n")
+     ((or (string= type "mediaGroup")
+          (string= type "mediaSingle"))
+      (jira-doc--format-media-block block))
      ((string= type "codeBlock")
       (concat "\n" (jira-fmt-code content) "\n"))
      ((string= type "blockquote")

--- a/jira-edit.el
+++ b/jira-edit.el
@@ -77,6 +77,15 @@
 (defconst jira-regexp-heading
   (rx bol "h" (submatch (any "1-6") ". " (*? not-newline)) eol))
 
+(defconst jira-regexp-table-row
+  (rx bol
+      (submatch
+       (submatch-n 2 "|" (? "|"))
+       (+ (+? (intersection (not "|") not-newline))
+          (backref 2))
+      (* not-newline)
+      eol)))
+
 (defconst jira-regexp-hr
   (rx bol "----"))
 
@@ -92,6 +101,8 @@
      0 'jira-face-blockquote prepend)
     (,jira-regexp-list-item
      1 font-lock-builtin-face)
+    (,jira-regexp-table-row
+     . 'jira-face-code)
     ;; can't use `jira-regexp-heading' because font-lock can't select
     ;; a face based on the contents of the match.
     (,(rx bol "h1. " (*? not-newline) eol)
@@ -175,6 +186,11 @@
 ;;   x = 42;
 ;; }
 ;; {code}
+
+;; Tables:
+;; ||heading 1||heading 2||heading 3||
+;; |col A1|col A2|col A3|
+;; |col B1|col B2|col B3|
 "
   "Instructions included in jira-edit-mode buffers.")
 

--- a/jira-fmt.el
+++ b/jira-fmt.el
@@ -138,6 +138,10 @@ For example:
   "Face for Jira inserted markup."
   :group 'jira)
 
+(defface jira-face-placeholder
+  '((t :inherit font-lock-comment-face))
+  "Face used to show Jira nodes that we don't actually display.")
+
 (defun jira-fmt--alist-p (value)
   (and value (listp value) (or (null value) (consp (car value)))))
 
@@ -305,6 +309,12 @@ Extracts name from the status object."
 	  (jira-fmt-set-face text 'jira-face-emoji-reference)
 	;; otherwise, `text' is probably a normal Unicode emoji
 	text)
+    ""))
+
+(defun jira-fmt-placeholder (text)
+  "Format TEXT as a placeholder."
+  (if (and (stringp text) (not (string-empty-p text)))
+      (jira-fmt-set-face text 'jira-face-placeholder)
     ""))
 
 (defun jira-fmt--color (color-hex)


### PR DESCRIPTION
My coworkers use screenshots all the time in Jira. We can't really display inline media yet -- the media API is [undocumented](https://jira.atlassian.com/browse/CLOUD-12467) -- but we can at least show that something belongs there. The media objects are usually stored in the attachments anyway, but frustratingly the attachment API doesn't give the media ID the attachment belongs to.

Also, I recently wanted to use a table in a comment, so I added support for displaying them and writing them in markup.