### PR TITLE
Display mediaInline nodes.

### DIFF
--- a/jira-doc.el
+++ b/jira-doc.el
@@ -180,7 +180,7 @@
       (jira-fmt-placeholder
        (format "<file:%s%s>"
                (if (string= "" collection) "" (concat collection ":"))
-               (if (string= "" alt) id alt))))))
+               (if (and alt (not (string= "" alt))) alt id))))))
 
 (defun jira-doc--format-table-row (block)
   (mapcar #'jira-doc--format-content-block


### PR DESCRIPTION
I don't know how to create these in either the web comment editor or the ADF Builder, but one of my coworkers found a way! They're undocumented but their structure is just like the `media` node type.