### PR TITLE
Fix issue creation on APIv3.

### DIFF
--- a/jira-complete.el
+++ b/jira-complete.el
@@ -33,7 +33,7 @@
 (require 'org)
 
 (require 'jira-api)
-
+(require 'jira-doc)
 
 (defconst jira-complete--not-allowed-schemas
   '("attachment", "timetracking")
@@ -200,7 +200,11 @@ FD comes from the result of the metadata call."
           (let ((selected (completing-read (format "Select a %s: " fname) choices nil t)))
             `((id . ,(cdr (assoc selected choices))))))))
      (t
-      (read-string (format "Enter value for field %s: " fname))))))
+      (let ((s (read-string (format "Enter value for field %s: " fname))))
+        (if (or (string= "Description" fname)
+                (string= "textarea" schema-type))
+            (jira-doc-build s)
+          s))))))
 
 
 (cl-defun jira-complete--issue-from-metadata


### PR DESCRIPTION
When I tried to create a subtask, it failed like this:

`((errorMessages . []) (errors (description . Operation value must be an Atlassian Document (see the Atlassian Document Format))))`

The doc for `POST /issue` says any `textarea` field value must be in ADF. It seems like "Description" is special: it gets `string` type, but unlike "Summary" which is also a string, descriptions must be in ADF. I'm not 100% sure this is correct: what if another custom field gets named "Description"? Should this fix be in `jira-complete-ask-issue-fields` instead?

While we're looking at this, what do you think about popping to a `jira-edit-mode` buffer for writing the description or other `textarea` fields?