### PR TITLE
feat: add hierarchical sorting for issue list

### DIFF
--- a/jira-utils.el
+++ b/jira-utils.el
@@ -153,7 +153,10 @@
     (:issuelinks . ((:path . (fields issuelinks))
                    (:columns . 15)
                    (:name . "Linked Issues")
-                   (:formatter . jira-fmt-issuelinks)))))
+                   (:formatter . jira-fmt-issuelinks)))
+    (:issue-type-subtask . ((:path . (fields issuetype subtask))
+                            (:columns . 5)
+                            (:name . "Subtask?")))))
 
 (defun jira-utils-marked-items ()
   "Return the marked items in the current tablist."


### PR DESCRIPTION
Add `parent` and `issuetype` to required fields for hierarchy detection, then add customization options to enable sorting by it (Epics first, children next, subtasks last) and displaying hierarchy via indentation.

When hierarchy sort is enabled, issues in the list display as:

```
EPIC-1       Epic    User Auth
  PROJ-10    Story   Login page
    PROJ-15  Subtask Validation
  PROJ-11    Story   Password reset
```