### PR TITLE
Fix transient-define-prefix autoloading error

### DIFF
--- a/jira-export.el
+++ b/jira-export.el
@@ -241,7 +241,7 @@ FORMAT-NAME is a string used in the docstring."
       (jira-export-menu)
     (message "Export is only available in jira-issues-mode")))
 
-;;;###autoload
+;;;###autoload (autoload 'jira-export-menu "jira-export" "Show menu for exporting Jira Issues." t)
 (transient-define-prefix jira-export-menu ()
   "Show menu for exporting Jira Issues."
   ["Export Format"


### PR DESCRIPTION
Fixes error on Emacs start
Error loading autoloads: (void-function transient-prefix)

Check - https://github.com/magit/transient/issues/280